### PR TITLE
Interpolator returns empty string on null

### DIFF
--- a/example/d3-interpolate-path.js
+++ b/example/d3-interpolate-path.js
@@ -184,15 +184,15 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
  * @param {String} b The `d` attribute for a path
  */
 function interpolatePath(a, b) {
-  var aNormalized = a == null ? null : a.replace(/[Z]/gi, '');
-  var bNormalized = b == null ? null : b.replace(/[Z]/gi, '');
-  var aPoints = aNormalized == null ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
-  var bPoints = bNormalized == null ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
+  var aNormalized = a == null ? '' : a.replace(/[Z]/gi, '');
+  var bNormalized = b == null ? '' : b.replace(/[Z]/gi, '');
+  var aPoints = aNormalized === '' ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
+  var bPoints = bNormalized === '' ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
 
-  // if both are empty, interpolation is always null.
+  // if both are empty, interpolation is always the empty string.
   if (!aPoints.length && !bPoints.length) {
     return function nullInterpolator() {
-      return null;
+      return '';
     };
   }
 
@@ -245,7 +245,7 @@ function interpolatePath(a, b) {
   return function pathInterpolator(t) {
     // at 1 return the final value without the extensions used during interpolation
     if (t === 1) {
-      return b;
+      return b == null ? '' : b;
     }
 
     return stringInterpolator(t);

--- a/src/interpolatePath.js
+++ b/src/interpolatePath.js
@@ -175,15 +175,15 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
  * @param {String} b The `d` attribute for a path
  */
 export default function interpolatePath(a, b) {
-  const aNormalized = a == null ? null : a.replace(/[Z]/gi, '');
-  const bNormalized = b == null ? null : b.replace(/[Z]/gi, '');
-  const aPoints = aNormalized == null ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
-  const bPoints = bNormalized == null ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
+  const aNormalized = a == null ? '' : a.replace(/[Z]/gi, '');
+  const bNormalized = b == null ? '' : b.replace(/[Z]/gi, '');
+  const aPoints = aNormalized === '' ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
+  const bPoints = bNormalized === '' ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
 
-  // if both are empty, interpolation is always null.
+  // if both are empty, interpolation is always the empty string.
   if (!aPoints.length && !bPoints.length) {
     return function nullInterpolator() {
-      return null;
+      return '';
     };
   }
 
@@ -235,7 +235,7 @@ export default function interpolatePath(a, b) {
   return function pathInterpolator(t) {
     // at 1 return the final value without the extensions used during interpolation
     if (t === 1) {
-      return b;
+      return b == null ? '' : b;
     }
 
     return stringInterpolator(t);

--- a/test/interpolatePath-test.js
+++ b/test/interpolatePath-test.js
@@ -108,7 +108,7 @@ tape('interpolatePath() interpolates line to line: B is null', function (t) {
   const interpolator = interpolatePath(a, b);
 
   t.equal(interpolator(0), a);
-  t.equal(interpolator(1), b);
+  t.equal(interpolator(1), '');
 
   // should be halfway towards the first point of a
   t.equal(interpolator(0.5), 'M0,0L5,5L50,50');
@@ -123,11 +123,11 @@ tape('interpolatePath() interpolates line to line: A is null and B is null', fun
 
   const interpolator = interpolatePath(a, b);
 
-  t.equal(interpolator(0), null);
-  t.equal(interpolator(1), null);
+  t.equal(interpolator(0), '');
+  t.equal(interpolator(1), '');
 
   // should be halfway towards the first point of a
-  t.equal(interpolator(0.5), null);
+  t.equal(interpolator(0.5), '');
 
   t.end();
 });


### PR DESCRIPTION
It turns out `attrTween` handles null differently than `attr` does and that **interpolators must return string values in all cases**. This updates the interpolator to conform by treating null values as the empty string.  See https://github.com/d3/d3-transition/issues/56 for details.