### PR TITLE
Fix IE11 path string error where spaces follow command characters

### DIFF
--- a/example/d3-interpolate-path.js
+++ b/example/d3-interpolate-path.js
@@ -184,8 +184,9 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
  * @param {String} b The `d` attribute for a path
  */
 function interpolatePath(a, b) {
-  var aNormalized = a == null ? '' : a.replace(/[Z]/gi, '');
-  var bNormalized = b == null ? '' : b.replace(/[Z]/gi, '');
+  // remove Z, remove spaces after letters as seen in IE
+  var aNormalized = a == null ? '' : a.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
+  var bNormalized = b == null ? '' : b.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
   var aPoints = aNormalized === '' ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
   var bPoints = bNormalized === '' ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
 

--- a/src/interpolatePath.js
+++ b/src/interpolatePath.js
@@ -175,8 +175,9 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
  * @param {String} b The `d` attribute for a path
  */
 export default function interpolatePath(a, b) {
-  const aNormalized = a == null ? '' : a.replace(/[Z]/gi, '');
-  const bNormalized = b == null ? '' : b.replace(/[Z]/gi, '');
+  // remove Z, remove spaces after letters as seen in IE
+  const aNormalized = a == null ? '' : a.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
+  const bNormalized = b == null ? '' : b.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
   const aPoints = aNormalized === '' ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
   const bPoints = bNormalized === '' ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
 

--- a/test/interpolatePath-test.js
+++ b/test/interpolatePath-test.js
@@ -229,3 +229,21 @@ tape('interpolatePath() adds to the closest point', function (t) {
 
   t.end();
 });
+
+tape('interpolatePath() handles the case where path commands are followed by a space', function (t) {
+  // IE bug fix.
+  const a = 'M 0 0 L 10 10 L 100 100';
+  const b = 'M10,10L20,20';
+
+  const interpolator = interpolatePath(a, b);
+
+  t.equal(interpolator(0), 'M0,0L10,10L100,100');
+
+  // should not be extended anymore and should match exactly
+  t.equal(interpolator(1), b);
+
+  // should be half way between the last point of B and the last point of A
+  t.equal(interpolator(0.5), 'M5,5L10,10L60,60');
+
+  t.end();
+});


### PR DESCRIPTION
There was an issue where IE automatically formats path `d` attributes to have spaces everywhere. e.g. `M10,20` becomes `M 10 20`. This caused an issue with the normalization I was doing that didn't catch this.