### PR TITLE
Improve curve interpolation and fix negative number bug

### DIFF
--- a/example/d3-interpolate-path.js
+++ b/example/d3-interpolate-path.js
@@ -160,10 +160,21 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
     extended.push(commandsToExtend[i]);
 
     for (var j = 1; j < counts[i] && numExtended < numPointsToExtend; j++) {
-      var commandToAdd = commandsToExtend[i];
+      var commandToAdd = Object.assign({}, commandsToExtend[i]);
       // don't allow multiple Ms
       if (commandToAdd.type === 'M') {
-        commandToAdd = Object.assign({}, commandToAdd, { type: 'L' });
+        commandToAdd.type = 'L';
+      } else {
+        // try to set control points to x and y
+        if (commandToAdd.x1 !== undefined) {
+          commandToAdd.x1 = commandToAdd.x;
+          commandToAdd.y1 = commandToAdd.y;
+        }
+
+        if (commandToAdd.x2 !== undefined) {
+          commandToAdd.x2 = commandToAdd.x;
+          commandToAdd.y2 = commandToAdd.y;
+        }
       }
       extended.push(commandToAdd);
       numExtended += 1;

--- a/example/d3-interpolate-path.js
+++ b/example/d3-interpolate-path.js
@@ -132,12 +132,21 @@ function convertToSameType(aCommand, bCommand) {
  */
 function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
   // map each command in B to a command in A by counting how many times ideally
-  // a command in A was in the initial path
-  var counts = referenceCommands.reduce(function (counts, refCommand) {
-    var minDistance = Math.abs(commandsToExtend[0].x - refCommand.x);
-    var minCommand = 0;
+  // a command in A was in the initial path (see https://github.com/pbeshai/d3-interpolate-path/issues/8)
+  var initialCommandIndex = commandsToExtend.length > 1 && commandsToExtend[0].type === 'M' ? 1 : 0;
+
+  var counts = referenceCommands.reduce(function (counts, refCommand, i) {
+    // skip first M
+    if (i === 0 && refCommand.type === 'M') {
+      counts[0] = 1;
+      return counts;
+    }
+
+    var minDistance = Math.abs(commandsToExtend[initialCommandIndex].x - refCommand.x);
+    var minCommand = initialCommandIndex;
+
     // find the closest point by X position in A
-    for (var j = 1; j < commandsToExtend.length; j++) {
+    for (var j = initialCommandIndex + 1; j < commandsToExtend.length; j++) {
       var distance = Math.abs(commandsToExtend[j].x - refCommand.x);
       if (distance < minDistance) {
         minDistance = distance;

--- a/example/d3-interpolate-path.js
+++ b/example/d3-interpolate-path.js
@@ -205,8 +205,8 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
  */
 function interpolatePath(a, b) {
   // remove Z, remove spaces after letters as seen in IE
-  var aNormalized = a == null ? '' : a.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
-  var bNormalized = b == null ? '' : b.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
+  var aNormalized = a == null ? '' : a.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\s*/gi, '$1');
+  var bNormalized = b == null ? '' : b.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\s*/gi, '$1');
   var aPoints = aNormalized === '' ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
   var bPoints = bNormalized === '' ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "watch": "rollup --config rollup.config.js --watch",
     "lint": "eslint -c .eslintrc.js src",
     "pretest": "npm run build",
-    "test": "tape 'test/**/*-test.js'",
+    "test": "tape 'test/**/*-test.js' | faucet",
+    "test:raw": "tape 'test/**/*-test.js'",
     "prepublish": "npm run lint && npm run test && uglifyjs build/d3-interpolate-path.js -c -m -o build/d3-interpolate-path.min.js",
     "postpublish": "zip -j build/d3-interpolate-path.zip -- LICENSE README.md build/d3-interpolate-path.js build/d3-interpolate-path.min.js"
   },
@@ -32,6 +33,7 @@
     "eslint": "^3.3.1",
     "eslint-config-airbnb-base": "^5.0.2",
     "eslint-plugin-import": "^1.13.0",
+    "faucet": "0.0.1",
     "rollup": "^0.34.10",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-watch": "^2.5.0",

--- a/src/interpolatePath.js
+++ b/src/interpolatePath.js
@@ -151,10 +151,21 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
     extended.push(commandsToExtend[i]);
 
     for (let j = 1; j < counts[i] && numExtended < numPointsToExtend; j++) {
-      let commandToAdd = commandsToExtend[i];
+      let commandToAdd = Object.assign({}, commandsToExtend[i]);
       // don't allow multiple Ms
       if (commandToAdd.type === 'M') {
-        commandToAdd = Object.assign({}, commandToAdd, { type: 'L' });
+        commandToAdd.type = 'L';
+      } else {
+        // try to set control points to x and y
+        if (commandToAdd.x1 !== undefined) {
+          commandToAdd.x1 = commandToAdd.x;
+          commandToAdd.y1 = commandToAdd.y;
+        }
+
+        if (commandToAdd.x2 !== undefined) {
+          commandToAdd.x2 = commandToAdd.x;
+          commandToAdd.y2 = commandToAdd.y;
+        }
       }
       extended.push(commandToAdd);
       numExtended += 1;

--- a/src/interpolatePath.js
+++ b/src/interpolatePath.js
@@ -123,12 +123,21 @@ function convertToSameType(aCommand, bCommand) {
  */
 function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
   // map each command in B to a command in A by counting how many times ideally
-  // a command in A was in the initial path
-  const counts = referenceCommands.reduce((counts, refCommand) => {
-    let minDistance = Math.abs(commandsToExtend[0].x - refCommand.x);
-    let minCommand = 0;
+  // a command in A was in the initial path (see https://github.com/pbeshai/d3-interpolate-path/issues/8)
+  const initialCommandIndex = commandsToExtend.length > 1 && commandsToExtend[0].type === 'M' ? 1 : 0;
+
+  const counts = referenceCommands.reduce((counts, refCommand, i) => {
+    // skip first M
+    if (i === 0 && refCommand.type === 'M') {
+      counts[0] = 1;
+      return counts;
+    }
+
+    let minDistance = Math.abs(commandsToExtend[initialCommandIndex].x - refCommand.x);
+    let minCommand = initialCommandIndex;
+
     // find the closest point by X position in A
-    for (let j = 1; j < commandsToExtend.length; j++) {
+    for (let j = initialCommandIndex + 1; j < commandsToExtend.length; j++) {
       const distance = Math.abs(commandsToExtend[j].x - refCommand.x);
       if (distance < minDistance) {
         minDistance = distance;

--- a/src/interpolatePath.js
+++ b/src/interpolatePath.js
@@ -196,8 +196,8 @@ function extend(commandsToExtend, referenceCommands, numPointsToExtend) {
  */
 export default function interpolatePath(a, b) {
   // remove Z, remove spaces after letters as seen in IE
-  const aNormalized = a == null ? '' : a.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
-  const bNormalized = b == null ? '' : b.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\W*/gi, '$1');
+  const aNormalized = a == null ? '' : a.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\s*/gi, '$1');
+  const bNormalized = b == null ? '' : b.replace(/[Z]/gi, '').replace(/([MLCSTQAHV])\s*/gi, '$1');
   const aPoints = aNormalized === '' ? [] : aNormalized.split(/(?=[MLCSTQAHV])/gi);
   const bPoints = bNormalized === '' ? [] : bNormalized.split(/(?=[MLCSTQAHV])/gi);
 

--- a/test/interpolatePath-test.js
+++ b/test/interpolatePath-test.js
@@ -250,7 +250,6 @@ tape('interpolatePath() handles the case where path commands are followed by a s
 
 
 tape('interpolatePath() includes M when extending if it is the only item', function (t) {
-  // IE bug fix.
   const a = 'M0,0';
   const b = 'M10,10L20,20L30,30';
 
@@ -267,3 +266,18 @@ tape('interpolatePath() includes M when extending if it is the only item', funct
   t.end();
 });
 
+
+tape('interpolatePath() handles negative numbers properly', function (t) {
+  const a = 'M0,0L0,0';
+  const b = 'M-10,-10L20,20';
+
+  const interpolator = interpolatePath(a, b);
+
+  t.equal(interpolator(0), 'M0,0L0,0');
+  t.equal(interpolator(1), b);
+
+  // should be half way between the last point of B and the last point of A
+  t.equal(interpolator(0.5), 'M-5,-5L10,10');
+
+  t.end();
+});

--- a/test/interpolatePath-test.js
+++ b/test/interpolatePath-test.js
@@ -27,7 +27,7 @@ tape('interpolatePath() interpolates line to line: len(A) > len(b)', function (t
   t.equal(interpolator(1), b);
 
   // should be half way between the last point of B and the last point of A
-  t.equal(interpolator(0.5), 'M5,5L10,10L60,60');
+  t.equal(interpolator(0.5), 'M5,5L15,15L60,60');
 
   t.end();
 });
@@ -198,17 +198,17 @@ tape('interpolatePath() converts points in A to match types in B', function (t) 
 
 
 tape('interpolatePath() interpolates curves of different length', function (t) {
-  const a = 'M0,0L0,0C0,0,0,0,0,0C0,0,0,0,0,0L0,0';
-  const b = 'M4,4L4,4C4,4,4,4,4,4C4,4,4,4,4,4C4,4,4,4,4,4C4,4,4,4,4,4L4,4';
+  const a = 'M0,0L3,3C1,1,2,2,4,4C3,3,4,4,6,6L8,0';
+  const b = 'M2,2L3,3C5,5,6,6,4,4C6,6,7,7,5,5C8,8,9,9,6,6C10,10,11,11,7,7L8,8';
 
 
   const interpolator = interpolatePath(a, b);
 
-  t.equal(interpolator(0), 'M0,0L0,0C0,0,0,0,0,0C0,0,0,0,0,0C0,0,0,0,0,0C0,0,0,0,0,0L0,0');
+  t.equal(interpolator(0), 'M0,0L3,3C1,1,2,2,4,4C4,4,4,4,4,4C3,3,4,4,6,6C6,6,6,6,6,6L8,0');
   t.equal(interpolator(1), b);
 
   // should be halfway towards the first point of a
-  t.equal(interpolator(0.5), 'M2,2L2,2C2,2,2,2,2,2C2,2,2,2,2,2C2,2,2,2,2,2C2,2,2,2,2,2L2,2');
+  t.equal(interpolator(0.5), 'M1,1L3,3C3,3,4,4,4,4C5,5,5.5,5.5,4.5,4.5C5.5,5.5,6.5,6.5,6,6C8,8,8.5,8.5,6.5,6.5L8,4');
 
   t.end();
 });
@@ -221,11 +221,11 @@ tape('interpolatePath() adds to the closest point', function (t) {
 
   const interpolator = interpolatePath(a, b);
 
-  t.equal(interpolator(0), 'M0,0L0,0L4,0L4,0L4,0L20,0L20,0');
+  t.equal(interpolator(0), 'M0,0L4,0L4,0L4,0L4,0L20,0L20,0');
   t.equal(interpolator(1), b);
 
   // should be halfway towards the first point of a
-  t.equal(interpolator(0.5), 'M0,2L0.5,2L3.5,0L4,0L7,0L17,0L19,0');
+  t.equal(interpolator(0.5), 'M0,2L2.5,2L3.5,0L4,0L7,0L17,0L19,0');
 
   t.end();
 });
@@ -243,7 +243,27 @@ tape('interpolatePath() handles the case where path commands are followed by a s
   t.equal(interpolator(1), b);
 
   // should be half way between the last point of B and the last point of A
-  t.equal(interpolator(0.5), 'M5,5L10,10L60,60');
+  t.equal(interpolator(0.5), 'M5,5L15,15L60,60');
 
   t.end();
 });
+
+
+tape('interpolatePath() includes M when extending if it is the only item', function (t) {
+  // IE bug fix.
+  const a = 'M0,0';
+  const b = 'M10,10L20,20L30,30';
+
+  const interpolator = interpolatePath(a, b);
+
+  t.equal(interpolator(0), 'M0,0L0,0L0,0');
+
+  // should not be extended anymore and should match exactly
+  t.equal(interpolator(1), b);
+
+  // should be half way between the last point of B and the last point of A
+  t.equal(interpolator(0.5), 'M5,5L10,10L15,15');
+
+  t.end();
+});
+


### PR DESCRIPTION
- Improves curve interpolation by setting control points to match their x,y position. This partially addresses #7. It's an improvement, but not the ideal fix. The ideal fix would, I believe, involve switching from using d3's interpolateString to doing the interpolation on the command objects themselves and splitting the curves (see http://www.iscriptdesign.com/?sketch=tutorial/splitbezier for an example of how to do it).
- Resolves #8 by ignoring the first command if it is an M when looking to extend a path. Prevents a curved line from switching from Cs to Ls if the new point was closer to the M command.
- Fixes a bug where negative numbers lost their negative signs.