### PR TITLE
Use babel-plugin-transform-object-assign for IE compatibility as Object.assign is not available in IE.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015-rollup": "^1.2.0",
     "eslint": "^3.3.1",
     "eslint-config-airbnb-base": "^5.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,9 @@ var globals = {
 export default {
   entry: 'index.js',
   moduleName: 'd3',
-  plugins: [babel()],
+  plugins: [babel({
+  	plugins: ['transform-object-assign'],
+  })],
   globals: globals,
   external: Object.keys(globals),
   targets: [


### PR DESCRIPTION
Replace Object.assign with an inline helper using babel-plugin-transform-object-assign.
I'm not sure if rollup configuration needs full plugin name or is ok with 'transform-object-assign' as I couldn't ran the tests on my windows machine.