### PR TITLE
Fix A command

### DIFF
--- a/docs/d3-interpolate-path.js
+++ b/docs/d3-interpolate-path.js
@@ -56,6 +56,26 @@ function _objectSpread(target) {
   return target;
 }
 
+function _toConsumableArray(arr) {
+  return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread();
+}
+
+function _arrayWithoutHoles(arr) {
+  if (Array.isArray(arr)) {
+    for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
+
+    return arr2;
+  }
+}
+
+function _iterableToArray(iter) {
+  if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter);
+}
+
+function _nonIterableSpread() {
+  throw new TypeError("Invalid attempt to spread non-iterable instance");
+}
+
 /**
  * de Casteljau's algorithm for drawing and splitting bezier curves.
  * Inspired by https://pomax.github.io/bezierinfo/
@@ -210,17 +230,40 @@ var commandTokenRegex = /[MLCSTQAHVmlcstqahv]|[\d.-]+/g;
  * List of params for each command type in a path `d` attribute
  */
 
+var numberInterpolate = function numberInterpolate(t, a, b) {
+  return (1 - t) * a + t * b;
+};
+
+var intInterpolate = function intInterpolate(t, a, b) {
+  return Math.round((1 - t) * a + t * b);
+};
+
+var toNumberCommand = function toNumberCommand(command) {
+  return {
+    name: command,
+    interpolate: numberInterpolate
+  };
+};
+
+var toIntCommand = function toIntCommand(command) {
+  return {
+    name: command,
+    interpolate: intInterpolate
+  };
+};
+
 var typeMap = {
-  M: ['x', 'y'],
-  L: ['x', 'y'],
-  H: ['x'],
-  V: ['y'],
-  C: ['x1', 'y1', 'x2', 'y2', 'x', 'y'],
-  S: ['x2', 'y2', 'x', 'y'],
-  Q: ['x1', 'y1', 'x', 'y'],
-  T: ['x', 'y'],
-  A: ['rx', 'ry', 'xAxisRotation', 'largeArcFlag', 'sweepFlag', 'x', 'y']
-}; // Add lower case entries too matching uppercase (e.g. 'm' == 'M')
+  M: ['x', 'y'].map(toNumberCommand),
+  L: ['x', 'y'].map(toNumberCommand),
+  H: ['x'].map(toNumberCommand),
+  V: ['y'].map(toNumberCommand),
+  C: ['x1', 'y1', 'x2', 'y2', 'x', 'y'].map(toNumberCommand),
+  S: ['x2', 'y2', 'x', 'y'].map(toNumberCommand),
+  Q: ['x1', 'y1', 'x', 'y'].map(toNumberCommand),
+  T: ['x', 'y'].map(toNumberCommand),
+  A: [].concat(_toConsumableArray(['rx', 'ry', 'xAxisRotation'].map(toNumberCommand)), _toConsumableArray(['largeArcFlag', 'sweepFlag'].map(toIntCommand)), _toConsumableArray(['x', 'y'].map(toNumberCommand)))
+}; // A: ['rx', 'ry', 'xAxisRotation', 'largeArcFlag', 'sweepFlag', 'x', 'y'].map(toNumberCommand),
+// Add lower case entries too matching uppercase (e.g. 'm' == 'M')
 
 Object.keys(typeMap).forEach(function (key) {
   typeMap[key.toLowerCase()] = typeMap[key];
@@ -244,7 +287,7 @@ function arrayOfLength(length, value) {
 
 function commandToString(command) {
   return "".concat(command.type).concat(typeMap[command.type].map(function (p) {
-    return command[p];
+    return command[p.name];
   }).join(','));
 }
 /**
@@ -450,7 +493,7 @@ function makeCommands(d) {
       }; // add each of the expected args for this command:
 
       for (var a = 0; a < commandArgs.length; ++a) {
-        command[commandArgs[a]] = +tokens[i + a + 1];
+        command[commandArgs[a].name] = +tokens[i + a + 1];
       } // need to increment our token index appropriately since
       // we consumed token args
 
@@ -538,7 +581,7 @@ function interpolatePath(a, b, excludeSegment) {
         try {
           for (var _iterator = typeMap[interpolatedCommand.type][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
             var arg = _step.value;
-            interpolatedCommand[arg] = (1 - t) * aCommand[arg] + t * bCommand[arg];
+            interpolatedCommand[arg.name] = arg.interpolate(t, aCommand[arg.name], bCommand[arg.name]);
           }
         } catch (err) {
           _didIteratorError = true;

--- a/src/interpolatePath.js
+++ b/src/interpolatePath.js
@@ -4,16 +4,21 @@ const commandTokenRegex = /[MLCSTQAHVmlcstqahv]|[\d.-]+/g;
 /**
  * List of params for each command type in a path `d` attribute
  */
+const numberInterpolate = (t, a, b) => (1 - t) * a + t * b;
+const intInterpolate = (t, a, b) => Math.round((1 - t) * a + t * b);
+const toNumberCommand = (command) => ({ name: command, interpolate: numberInterpolate });
+const toIntCommand = (command) => ({ name: command, interpolate: intInterpolate });
+
 const typeMap = {
-  M: ['x', 'y'],
-  L: ['x', 'y'],
-  H: ['x'],
-  V: ['y'],
-  C: ['x1', 'y1', 'x2', 'y2', 'x', 'y'],
-  S: ['x2', 'y2', 'x', 'y'],
-  Q: ['x1', 'y1', 'x', 'y'],
-  T: ['x', 'y'],
-  A: ['rx', 'ry', 'xAxisRotation', 'largeArcFlag', 'sweepFlag', 'x', 'y'],
+  M: ['x', 'y'].map(toNumberCommand),
+  L: ['x', 'y'].map(toNumberCommand),
+  H: ['x'].map(toNumberCommand),
+  V: ['y'].map(toNumberCommand),
+  C: ['x1', 'y1', 'x2', 'y2', 'x', 'y'].map(toNumberCommand),
+  S: ['x2', 'y2', 'x', 'y'].map(toNumberCommand),
+  Q: ['x1', 'y1', 'x', 'y'].map(toNumberCommand),
+  T: ['x', 'y'].map(toNumberCommand),
+  A: [ ...['rx', 'ry', 'xAxisRotation'].map(toNumberCommand), ...['largeArcFlag', 'sweepFlag'].map(toIntCommand), ...['x', 'y'].map(toNumberCommand)],
 };
 
 // Add lower case entries too matching uppercase (e.g. 'm' == 'M')
@@ -37,7 +42,7 @@ function arrayOfLength(length, value) {
  */
 function commandToString(command) {
   return `${command.type}${typeMap[command.type]
-    .map(p => command[p])
+    .map(p => command[p.name])
     .join(',')}`;
 }
 
@@ -284,7 +289,7 @@ function makeCommands(d) {
 
       // add each of the expected args for this command:
       for (let a = 0; a < commandArgs.length; ++a) {
-        command[commandArgs[a]] = +tokens[i + a + 1];
+        command[commandArgs[a].name] = +tokens[i + a + 1];
       }
 
       // need to increment our token index appropriately since
@@ -372,8 +377,7 @@ export default function interpolatePath(a, b, excludeSegment) {
         const bCommand = bCommands[i];
         const interpolatedCommand = interpolatedCommands[i];
         for (const arg of typeMap[interpolatedCommand.type]) {
-          interpolatedCommand[arg] =
-            (1 - t) * aCommand[arg] + t * bCommand[arg];
+          interpolatedCommand[arg.name] = arg.interpolate(t, aCommand[arg.name], bCommand[arg.name]);
         }
       }
     }

--- a/test/interpolatePath-test.js
+++ b/test/interpolatePath-test.js
@@ -247,7 +247,7 @@ tape('interpolatePath() interpolates with other valid `d` characters', function(
   t.equal(
     interpolator(0.5),
     'M2,2m2,2L2,2l2,2H2V2Q2,2,2,2q2,2,2,2C2,2,2,2,2,2c2,2,2,2,2,2' +
-      'T2,2t2,2S2,2,2,2s2,2,2,2A2,2,0.5,0.5,0.5,2,2'
+      'T2,2t2,2S2,2,2,2s2,2,2,2A2,2,0.5,1,1,2,2'
   );
 
   t.end();

--- a/test/interpolatePath-test.js
+++ b/test/interpolatePath-test.js
@@ -210,6 +210,24 @@ tape('interpolatePath() interpolates where A=null, B ends in Z', function(t) {
   t.end();
 });
 
+tape('interpolatePath() interpolates A command using integer value', function(t) {
+  const a = 'A10,10,0,0,1,20,20';
+  const b = 'A20,20,40,1,0,10,10';
+
+  const interpolator = interpolatePath(a, b);
+
+  // should be extended to match the length of b
+  t.equal(interpolator(0), a);
+  t.equal(interpolator(1), b);
+
+  // should be half way between the last point of B and the last point of A
+  t.equal(interpolator(0.5), 'A15,15,20,1,1,15,15');
+  t.equal(interpolator(0.75), 'A17.5,17.5,30,1,0,12.5,12.5');
+  t.equal(interpolator(0.25), 'A12.5,12.5,10,0,1,17.5,17.5');
+
+  t.end();
+});
+
 tape('interpolatePath() interpolates with other valid `d` characters', function(
   t
 ) {


### PR DESCRIPTION
First, thanks  a lot for this very usefull utility.

 I found out that when interpolating a A command, this library interpolates `largeArcFlag` and `sweepFlag` with decimal values values whereas by definition they [can only be 0 or 1](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#Elliptical_Arc_Curve).


This causes this error:

![image](https://user-images.githubusercontent.com/524617/63226665-f88f6f80-c1b2-11e9-8ace-c1dea7baeb7c.png)

This PR correct this behavior providing integer interpolation for `largeArcFlag` and `sweepFlag`.

It cames also with corresponding tests.